### PR TITLE
os.Environ() on "docker-applyLayer" like on "docker-untar"

### DIFF
--- a/pkg/chrootarchive/diff_unix.go
+++ b/pkg/chrootarchive/diff_unix.go
@@ -110,7 +110,7 @@ func applyLayerHandler(dest string, layer io.Reader, options *archive.TarOptions
 
 	cmd := reexec.Command("docker-applyLayer", dest)
 	cmd.Stdin = layer
-	cmd.Env = append(cmd.Env, fmt.Sprintf("OPT=%s", data))
+	cmd.Env = append(os.Environ(), fmt.Sprintf("OPT=%s", data))
 
 	outBuf, errBuf := new(bytes.Buffer), new(bytes.Buffer)
 	cmd.Stdout, cmd.Stderr = outBuf, errBuf


### PR DESCRIPTION
Unlike the `docker-untar` call, the `docker-applyLayer` call does not get the environment variables.

In this `strace `extract, we see that all calls (in particular `docker-untar`) to `execve `receive the environment variables. The only exception is `docker-applyLayer` who only got `OPT `environment variable.

```
	127   execve("/usr/bin/docker-containerd", ["docker-containerd", "-l", "unix:///var/run/docker/libcontainerd/docker-containerd.sock", "--metrics-interval=0", "--start-timeout", "2m", "--state-dir", "/var/run/docker/libcontainerd/containerd", "--shim", "docker-containerd-shim", "--runtime", "docker-runc"], ["HOSTNAME=blder-admn-doc01", "HOME=/root", "container=docker", "TERM=xterm", "LD_DEBUG=bindings", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "LANG=fr_FR.UTF-8", "LD_DEBUG_OUTPUT=/var/tmp/sym.log", "PWD=/"]) = 0
	191   execve("/usr/bin/docker-runc", ["docker-runc", "--version"], ["HOSTNAME=blder-admn-doc01", "HOME=/root", "container=docker", "TERM=xterm", "LD_DEBUG=bindings", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "LANG=fr_FR.UTF-8", "LD_DEBUG_OUTPUT=/var/tmp/sym.log", "PWD=/", "TMPDIR=/var/lib/docker/tmp"]) = 0
	198   execve("/usr/bin/docker-init", ["docker-init", "--version"], ["HOSTNAME=blder-admn-doc01", "HOME=/root", "container=docker", "TERM=xterm", "LD_DEBUG=bindings", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "LANG=fr_FR.UTF-8", "LD_DEBUG_OUTPUT=/var/tmp/sym.log", "PWD=/", "TMPDIR=/var/lib/docker/tmp"]) = 0
	199   execve("/usr/bin/docker-runc", ["docker-runc", "--version"], ["HOSTNAME=blder-admn-doc01", "HOME=/root", "container=docker", "TERM=xterm", "LD_DEBUG=bindings", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "LANG=fr_FR.UTF-8", "LD_DEBUG_OUTPUT=/var/tmp/sym.log", "PWD=/", "TMPDIR=/var/lib/docker/tmp"]) = 0
	204   execve("/usr/bin/docker-init", ["docker-init", "--version"], ["HOSTNAME=blder-admn-doc01", "HOME=/root", "container=docker", "TERM=xterm", "LD_DEBUG=bindings", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "LANG=fr_FR.UTF-8", "LD_DEBUG_OUTPUT=/var/tmp/sym.log", "PWD=/", "TMPDIR=/var/lib/docker/tmp"]) = 0
	205   execve("/proc/self/exe", ["docker-untar", "/var/lib/docker/tmp/docker-builder593893700"], ["HOSTNAME=blder-admn-doc01", "HOME=/root", "container=docker", "TERM=xterm", "LD_DEBUG=bindings", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "LANG=fr_FR.UTF-8", "LD_DEBUG_OUTPUT=/var/tmp/sym.log", "PWD=/", "TMPDIR=/var/lib/docker/tmp"]) = 0
	211   execve("/proc/self/exe", ["docker-untar", "/var/lib/docker/volumes/580edad5eaac3d4b0d82661380768d56af6ccc89f14e537f109bc4862e47fc72/_data"], ["HOSTNAME=blder-admn-doc01", "HOME=/root", "container=docker", "TERM=xterm", "LD_DEBUG=bindings", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "LANG=fr_FR.UTF-8", "LD_DEBUG_OUTPUT=/var/tmp/sym.log", "PWD=/", "TMPDIR=/var/lib/docker/tmp"]) = 0
	218   execve("/proc/self/exe", ["docker-applyLayer", "/var/lib/docker/overlay/88ec05c838eca2c4efd12f9e2ebc34b53e4b46f41fc941ea5ad03a8294080f2c/tmproot204643841"], ["OPT={\"IncludeFiles\":null,\"ExcludePatterns\":[],\"Compression\":0,\"NoLchown\":false,\"UIDMaps\":null,\"GIDMaps\":null,\"ChownOpts\":null,\"IncludeSourceDir\":false,\"WhiteoutFormat\":0,\"NoOverwriteDirNonDir\":false,\"RebaseNames\":null,\"InUserNS\":false}"]) = 0
	224   execve("/proc/self/exe", ["docker-untar", "/var/lib/docker/volumes/c60d586077141f577171912f5326bf6447396530e8d74f1902b03be2a851420c/_data"], ["HOSTNAME=blder-admn-doc01", "HOME=/root", "container=docker", "TERM=xterm", "LD_DEBUG=bindings", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "LANG=fr_FR.UTF-8", "LD_DEBUG_OUTPUT=/var/tmp/sym.log", "PWD=/", "TMPDIR=/var/lib/docker/tmp"]) = 0
	231   execve("/usr/bin/docker-containerd-shim", ["docker-containerd-shim", "58c8d232adf59d2351793b045af8ef08886f17a9256d0c588eef4a2ce098886d", "/var/run/docker/libcontainerd/58c8d232adf59d2351793b045af8ef08886f17a9256d0c588eef4a2ce098886d", "docker-runc"], ["HOSTNAME=blder-admn-doc01", "HOME=/root", "container=docker", "TERM=xterm", "LD_DEBUG=bindings", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "LANG=fr_FR.UTF-8", "LD_DEBUG_OUTPUT=/var/tmp/sym.log", "PWD=/"]) = 0
	237   execve("/usr/bin/docker-runc", ["docker-runc", "--log", "/run/docker/libcontainerd/containerd/58c8d232adf59d2351793b045af8ef08886f17a9256d0c588eef4a2ce098886d/init/log.json", "--log-format", "json", "create", "--bundle", "/var/run/docker/libcontainerd/58c8d232adf59d2351793b045af8ef08886f17a9256d0c588eef4a2ce098886d", "--pid-file", "/run/docker/libcontainerd/containerd/58c8d232adf59d2351793b045af8ef08886f17a9256d0c588eef4a2ce098886d/init/pid", "58c8d232adf59d2351793b045af8ef08886f17a9256d0c588eef4a2ce098886d"], ["HOSTNAME=blder-admn-doc01", "HOME=/root", "container=docker", "TERM=xterm", "LD_DEBUG=bindings", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "LANG=fr_FR.UTF-8", "LD_DEBUG_OUTPUT=/var/tmp/sym.log", "PWD=/"]) = 0
	268   execve("/usr/bin/docker-runc", ["docker-runc", "start", "58c8d232adf59d2351793b045af8ef08886f17a9256d0c588eef4a2ce098886d"], ["HOSTNAME=blder-admn-doc01", "HOME=/root", "container=docker", "TERM=xterm", "LD_DEBUG=bindings", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "LANG=fr_FR.UTF-8", "LD_DEBUG_OUTPUT=/var/tmp/sym.log", "PWD=/"]) = 0
	276   execve("/usr/bin/docker-runc", ["docker-runc", "kill", "--all", "58c8d232adf59d2351793b045af8ef08886f17a9256d0c588eef4a2ce098886d", "SIGKILL"], ["HOSTNAME=blder-admn-doc01", "HOME=/root", "container=docker", "TERM=xterm", "LD_DEBUG=bindings", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "LANG=fr_FR.UTF-8", "LD_DEBUG_OUTPUT=/var/tmp/sym.log", "PWD=/"]) = 0
	281   execve("/usr/bin/docker-runc", ["docker-runc", "delete", "58c8d232adf59d2351793b045af8ef08886f17a9256d0c588eef4a2ce098886d"], ["HOSTNAME=blder-admn-doc01", "HOME=/root", "container=docker", "TERM=xterm", "LD_DEBUG=bindings", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "LANG=fr_FR.UTF-8", "LD_DEBUG_OUTPUT=/var/tmp/sym.log", "PWD=/"]) = 0
	286   execve("/usr/bin/docker-runc", ["docker-runc", "delete", "58c8d232adf59d2351793b045af8ef08886f17a9256d0c588eef4a2ce098886d"], ["HOSTNAME=blder-admn-doc01", "HOME=/root", "container=docker", "TERM=xterm", "LD_DEBUG=bindings", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "LANG=fr_FR.UTF-8", "LD_DEBUG_OUTPUT=/var/tmp/sym.log", "PWD=/"]) = 0
	291   execve("/proc/self/exe", ["docker-applyLayer", "/var/lib/docker/overlay/928a21d29dc6641b80fab584f072c467a1bad5058b33cf1f5ffdcd71e584634b/tmproot106469052"], ["OPT={\"IncludeFiles\":null,\"ExcludePatterns\":[],\"Compression\":0,\"NoLchown\":false,\"UIDMaps\":null,\"GIDMaps\":null,\"ChownOpts\":null,\"IncludeSourceDir\":false,\"WhiteoutFormat\":0,\"NoOverwriteDirNonDir\":false,\"RebaseNames\":null,\"InUserNS\":false}"]) = 0
```
This is due to the following code of the `golang` project :
https://github.com/golang/go/blob/2b7a7b710f096b1b7e6f2ab5e9e3ec003ad7cd12/src/os/exec/exec.go#L167-L172

In the code calling `docker-applyLayer`, the Env attribute is created. `execve` get only `OPT`.
https://github.com/moby/moby/blob/c3a02077149ea8ee1d53b2b60a3d36c29d1505f8/pkg/chrootarchive/diff_unix.go#L85-L130

In the code calling `docker-untar`, the Env attribute is not created. `exceve` get `os.Environ()`.
https://github.com/moby/moby/blob/c3a02077149ea8ee1d53b2b60a3d36c29d1505f8/pkg/chrootarchive/archive_unix.go#L48-L88

To be consistent between docker-applyLayer and docker-untar, I propose to add OPT to `os.Environ()`.

Fixes #37537

Signed-off-by: Philippe GONCALVES <github@feeloo007.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Replace default value before `append` to `Cmd.Env`.

**- How I did it**

**- How to verify it**
with `strace`, execve for docker-applyLayer got more variables.

**- Description for the changelog**
<!--
-->
populate environment variables during `docker-ApplyLayer`.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/961458/43280255-995ecade-9110-11e8-9944-5b952c34420f.png)
